### PR TITLE
Fix #11: Add emacs keybindings and use commands.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,11 @@
+0.8.3 (Pending)
+===============
+
+* Add `Ctrl-p`/`Ctrl-n` and `Ctrl-i`/`Ctrl-k` as alternative keybindings
+  for moving through the file list, and use commands for all keybindings
+  to make customization easier.
+
+
 0.8.2 (August 3 2015)
 =====================
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,44 @@ symbol will add it as a project directory.
 `Cmd-Z`/`Ctrl-Z` will undo changes made to the current path, such as
 autocompletion or directory shortcuts.
 
-You can also remap the command to any key you want. For example, add the
-following to your keymap to map `Ctrl-x Ctrl-f` to open the dialog:
+## Keybindings
+
+Available commands for binding:
+
+<dl>
+  <dt>`advanced-open-file:toggle`</dt>
+  <dd>Toggles the Advanced Open File dialog.</dd>
+
+  <dt>`advanced-open-file:autocomplete`</dt>
+  <dd>Attempts to autocomplete the current input.</dd>
+
+  <dt>`advanced-open-file:undo`</dt>
+  <dd>Undo changes to the current path.</dd>
+
+  <dt>`advanced-open-file:move-cursor-up`</dt>
+  <dd>Move the cursor/highlight for the currently selected file up.</dd>
+
+  <dt>`advanced-open-file:move-cursor-down`</dt>
+  <dd>Move the cursor/highlight for the currently selected file down.</dd>
+</dl>
+
+The following extra keybindings are included by default:
+
+Action                                | Extra Keys
+------------------------------------- | ------------------
+`advanced-open-file:move-cursor-up`   | `Ctrl-p`, `Ctrl-i`
+`advanced-open-file:move-cursor-down` | `Ctrl-n`, `Ctrl-k`
+
+You can of course remap the keys however you wish. For example, add the
+following to your keymap to map `Ctrl-x Ctrl-f` to toggle the dialog and
+`Ctrl-j` to move the cursor down:
 
 ```cson
 'atom-workspace':
   'ctrl-x ctrl-f': 'advanced-open-file:toggle'
+
+'.advanced-open-file atom-text-editor':
+  'ctrl-j': 'advanced-open-file:move-cursor-down'
 ```
 
 ## Settings:

--- a/keymaps/advanced-open-file.cson
+++ b/keymaps/advanced-open-file.cson
@@ -12,3 +12,22 @@
 
 '.platform-win32 atom-workspace, .platform-linux atom-workspace':
   'ctrl-alt-o': 'advanced-open-file:toggle'
+
+'.advanced-open-file atom-text-editor':
+  'tab': 'advanced-open-file:autocomplete'
+  'up': 'advanced-open-file:move-cursor-up'
+  'down': 'advanced-open-file:move-cursor-down'
+
+  # Emacs-style movement
+  'ctrl-p': 'advanced-open-file:move-cursor-up'
+  'ctrl-n': 'advanced-open-file:move-cursor-down'
+
+  # Alternative movement keys
+  'ctrl-i': 'advanced-open-file:move-cursor-up'
+  'ctrl-k': 'advanced-open-file:move-cursor-down'
+
+'.platform-darwin .advanced-open-file atom-text-editor':
+  'cmd-z': 'advanced-open-file:undo'
+
+'.platform-win32 .advanced-open-file atom-text-editor, .platform-linux .advanced-open-file atom-text-editor':
+  'ctrl-z': 'advanced-open-file:undo'


### PR DESCRIPTION
Add extra keybindings for navigation through the file list, and switch to using
commands for implementing keybindings so users can customize them to their
heart's content.

@nomatics Would you be willing to pull this down and test out if it works? Also if you want to glance through the code and leave any feedback that'd be great! :D

@mythmon r? if you're tired of fixing your media center :P