### PR TITLE
Fix #13: Fix Windows path handling.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,11 @@
-0.8.3 (Pending)
+0.9.0 (Pending)
 ===============
 
+* Fix handling of Windows paths by replace all forward-slash instances
+  with path.sep, and detecting the root directory for a path better.
+* Removed support for creating multiple paths at once, as it doesn't
+  really fit with what advanced-open-file is about and made the code
+  harder to understand.
 * Add `Ctrl-p`/`Ctrl-n` and `Ctrl-i`/`Ctrl-k` as alternative keybindings
   for moving through the file list, and use commands for all keybindings
   to make customization easier.


### PR DESCRIPTION
Also removes support for creating multiple files at once; refactoring
the code to support Windows paths created some bugs that involved fixing
the multiple-file code, which I didn't think we needed anyway.

@NuclearCookie Would you be able to pull down this branch and test it to see if it works on your Windows machine? I don't have one set up to test this easily and I'd rather make sure I fixed your specific problem anyway. :D