### PR TITLE
Add file created event

### DIFF
--- a/lib/advanced-open-file-view.coffee
+++ b/lib/advanced-open-file-view.coffee
@@ -253,6 +253,7 @@ class AdvancedFileView extends View
               mkdirp createWithin unless fs.existsSync(createWithin) and fs.statSync(createWithin)
               touch pathToCreate
             atom.workspace.open pathToCreate
+            atom.emitter.emit 'advanced-open-file-created', pathToCreate
         catch error
           @setMessage "alert", error.message
 


### PR DESCRIPTION
Originally proposed in https://github.com/Trudko/advanced-new-file/pull/43

> PR is adding just one line of code - emitting message ( with file path) to Atom emitter when file is created. Having it will make easier to react on file creation for other plugins, which can be very useful in some cases ( for example adding file name to project file used by some programming languages)