### PR TITLE
Show details when we fail to list a directory.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,8 @@
   shortcut `:/` for switching to the project root directory.
 * Only show the parent directory in the listing if the file list is not being
   filtered.
+* Show error message when we fail to list directory contents, such as when the
+  user doesn't have permission to read the directory.
 
 
 0.9.2 (September 7, 2015)

--- a/lib/advanced-open-file-view.coffee
+++ b/lib/advanced-open-file-view.coffee
@@ -114,6 +114,8 @@ class AdvancedFileView extends View
         "Enter the path for the file/directory. Directories end with a "#{path.sep}"."
       @subview "miniEditor", new TextEditorView({mini:true})
       @subview "directoryListView", new DirectoryListView()
+      @div class: 'settings-view', => # Piggyback on settings view styles.
+        @div class: 'alert alert-error icon icon-alert', style: 'display: none', outlet: 'errorMessage'
 
   @detaching: false,
 
@@ -164,6 +166,9 @@ class AdvancedFileView extends View
     else
       return path.dirname(input)
 
+  showError: (message) ->
+    @directoryListView.hide()
+    @errorMessage.show().text(message)
 
   # Returns the list of directories matching the current input (path and autocomplete fragment)
   getFileList: (callback) ->
@@ -175,6 +180,10 @@ class AdvancedFileView extends View
         return []
 
       fs.readdir inputPath, (err, files) =>
+        if err?
+          @showError("Could not read directory contents: #{err.toString()}")
+          return
+
         fileList = []
         dirList = []
 
@@ -279,6 +288,8 @@ class AdvancedFileView extends View
     showOpenAsProjectFolder = not withinProjectFolder and not isProjectFolder
 
     showParent = inputPath and inputPath.endsWith(path.sep) and not isRoot(inputPath)
+    @errorMessage.hide()
+    @directoryListView.show()
     @directoryListView.renderFiles files, showParent, showOpenAsProjectFolder
 
   confirm: ->

--- a/styles/advanced-open-file.less
+++ b/styles/advanced-open-file.less
@@ -2,6 +2,11 @@
     display: flex;
     flex-direction: column;
 
+    .alert {
+        width: 100%;
+        margin-bottom: 0;
+    }
+
     .icon-file-add,
     .icon-file-directory-create {
         padding-left: 10px;


### PR DESCRIPTION
@mythmon r?

Eventually I'd like to make this less error-specific for things like showing a message when the user is creating a path that doesn't exist yet (rather than just showing nothing, like we currently do) but this is fine for now.