### PR TITLE
Require path separator before shortcuts and ignore all stat errors.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,12 @@
+0.12.4 (Pending)
+================
+
+* Ignore all errors when running stat on files and treat them as if they don't
+  exist. Previously only ENOENT errors were ignored.
+* Fix bug in path shortcuts where they were being applied even if a path
+  separator wasn't before the shortcut itself.
+
+
 0.12.3 (November 14, 2015)
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Advanced Open File
 
-[![Build Status](https://travis-ci.org/Osmose/advanced-open-file.svg)](https://travis-ci.org/Osmose/advanced-open-file)
+[![TravisCI Build Status](https://travis-ci.org/Osmose/advanced-open-file.svg)](https://travis-ci.org/Osmose/advanced-open-file)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/cwyb7f46dd1bbuxh/branch/master?svg=true)](https://ci.appveyor.com/project/Osmose/advanced-open-file/branch/master)
+
+
 
 Advanced Open File is a package for helping Atom users to open files and folders
 easily. It can also create new files and folders if they don't exist.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: "{build}"
+os: Windows Server 2012 R2
+
+test: off
+deploy: off
+
+environment:
+  AOF_WINDOWS_TESTS: 1
+
+install:
+  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
+  - AtomSetup.exe /silent
+
+build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
+  - apm clean
+  - apm install
+  - apm test

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -53,16 +53,17 @@ export class AdvancedOpenFileController {
         // Since the user typed this, apply fast-dir-switch
         // shortcuts.
         if (atom.config.get('advanced-open-file.helmDirSwitch')) {
-            if (newPath.directory.endsWith(newPath.sep + newPath.sep)) {
+            let sep = newPath.sep;
+            if (newPath.directory.endsWith(sep + sep)) {
                 newPath = newPath.root();
                 saveHistory = true;
-            } else if (newPath.directory.endsWith('~' + newPath.sep)) {
+            } else if (newPath.directory.endsWith(sep + '~' + sep)) {
                 newPath = new Path(osenv.home() + stdPath.sep);
                 saveHistory = true;
-            } else if (newPath.directory.endsWith(':' + newPath.sep)) {
+            } else if (newPath.directory.endsWith(sep + ':' + sep)) {
                 let projectPath = getProjectPath();
                 if (projectPath) {
-                    newPath = new Path(projectPath + newPath.sep);
+                    newPath = new Path(projectPath + sep);
                     saveHistory = true;
                 }
             }

--- a/lib/models.js
+++ b/lib/models.js
@@ -40,11 +40,7 @@ export class Path {
         try {
             return fs.statSync(absolutify(this.full));
         } catch (err) {
-            if (err.code === 'ENOENT') {
-                return null;
-            } else {
-                throw err;
-            }
+            return null;
         }
     }
 

--- a/spec/advanced-open-file-spec.js
+++ b/spec/advanced-open-file-spec.js
@@ -317,7 +317,7 @@ describe('Functional tests', () => {
 
         it('can switch to the user\'s home directory using a shortcut', () => {
             atom.config.set('advanced-open-file.helmDirSwitch', true);
-            setPath(fixturePath('subdir') + '~' + stdPath.sep);
+            setPath(fixturePath('subdir') + stdPath.sep + '~' + stdPath.sep);
             expect(currentPath()).toEqual(osenv.home() + stdPath.sep);
         });
 
@@ -333,7 +333,7 @@ describe('Functional tests', () => {
         it('can switch to the project root directory using a shortcut', () => {
             atom.config.set('advanced-open-file.helmDirSwitch', true);
             atom.project.setPaths([fixturePath('examples')]);
-            setPath(fixturePath('subdir') + ':' + stdPath.sep);
+            setPath(fixturePath('subdir') + stdPath.sep + ':' + stdPath.sep);
             expect(currentPath()).toEqual(fixturePath('examples') + stdPath.sep);
         });
     });
@@ -635,6 +635,25 @@ describe('Functional tests', () => {
             dispatch('core:confirm');
             expect(handler).toHaveBeenCalledWith(path);
             sub.dispose();
+        });
+    });
+
+    // Only run Windows-specific tests when enabled.
+    let windowsDescribe = process.env.AOF_WINDOWS_TESTS ? describe : xdescribe;
+    windowsDescribe('Windows-specific tests', () => {
+        // Just as a note, we're assuming C:\ exists and is the root
+        // system drive. It is on AppVeyor, and that's good enough.
+
+        it('can read the root directory without failing', () => {
+            // This potentially fails because we stat in-use files like
+            // pagefile.sys.
+            expect(() => {setPath('C:\\')}).not.toThrow();
+        });
+
+        it('does not replace drive letters with the project root', () => {
+            atom.project.setPaths([fixturePath()]);
+            setPath('C:/');
+            expect(currentPath()).toEqual('C:/');
         });
     });
 });

--- a/styles/advanced-open-file.less
+++ b/styles/advanced-open-file.less
@@ -56,5 +56,9 @@
         &:hover {
             background: @background-color-highlight;
         }
+
+        &.iffy {
+            color: @text-color-subtle;
+        }
     }
 }


### PR DESCRIPTION
I'm also going to handle the drive letter issues but want to get a PR up to test AppVeyor.