### PR TITLE
Fix #72: Calculate modal max-height.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,8 @@
   directory switching is turned off.
 * #70: Add setting for enabling directory creation from the open dialog.
 * #61: Add keyboard shortcut for adding project directories.
+* #72: Determine modal max height programmatically for themes that place modals
+  at odd positions.
 
 
 0.12.3 (November 14, 2015)

--- a/lib/view.js
+++ b/lib/view.js
@@ -102,7 +102,7 @@ export default class AdvancedOpenFileView {
         });
 
         let modal = this.content.parentNode;
-        modal.style.maxHeight = '100%';
+        modal.style.maxHeight = `${document.body.clientHeight - modal.offsetTop}px`;
         modal.style.display = 'flex';
         modal.style.flexDirection = 'column';
 

--- a/styles/advanced-open-file.less
+++ b/styles/advanced-open-file.less
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    z-index: 100;
 
     .hidden {
         display: none;


### PR DESCRIPTION
Also fixes an issue with themes mucking with z-indexes such that you can't click the modal.

@Traverse Does this solve your issue?

Note that this intentionally doesn't handle the edge case of resizing the window while the modal is open because it'd be a bit complex to update automatically (and would cost some CPU by possibly triggering reflows during the resize event) and probably just won't happen often enough to matter.