### PR TITLE
Fix moving cursors when fuzzy matching is enabled

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -147,7 +147,7 @@ export class AdvancedOpenFileContent extends Component {
     }
 
     updateMatchingPaths(path) {
-        let matchingPaths = fileService.getMatchingPaths(path);
+        let matchingPaths = fileService.getMatchingPaths(path).slice();
 
         if (!config.get('fuzzyMatch')) {
             matchingPaths = matchingPaths.sort(Path.compare);


### PR DESCRIPTION
This fixes #105.

When fuzzy matching is enabled, the if statement in [view.js#L152-L159](https://github.com/Osmose/advanced-open-file/blob/v0.16.1/lib/view.js#L152-L159) is not executed and `matchingPaths` in this scope is equal to ones in `file-service`'s `matchingPathCache`. So `matchingPaths.unshift` in [view.js#L169](https://github.com/Osmose/advanced-open-file/blob/v0.16.1/lib/view.js#L169) updates the cache itself, which causes incorrect behaviour.