### PR TITLE
for add-project-folder, use current path if non selected

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,3 +17,4 @@
 - [AlexWayfer](https://github.com/AlexWayfer)
 - [jacobmischka](https://github.com/jacobmischka)
 - [lee-dohm](https://github.com/lee-dohm)
+- [toumorokoshi](https://github.com/toumorokoshi)

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Available commands for binding:
 
   <dt><code>application:add-project-folder</code></dt>
   <dd>
-    If a folder path has been selected with the cursor, add it as a project
-    directory.
+    If either a folder path has been selected with the cursor, or the current
+    path is a folder, add that path as a project directory.
   </dd>
 
   <dt><code>advanced-open-file:autocomplete</code></dt>

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -196,7 +196,10 @@ export class AdvancedOpenFileController {
         event.stopPropagation();
 
         let selectedPath = this.view.selectedPath();
-        if (selectedPath !== null && !selectedPath.equals(this.currentPath.parent())) {
+        if (selectedPath == null && this.currentPath.isDirectory()) {
+            this.addProjectFolder(this.currentPath.full);
+        }
+        else if (selectedPath !== null && !selectedPath.equals(this.currentPath.parent())) {
             this.addProjectFolder(selectedPath.full);
         } else {
             atom.beep();

--- a/spec/advanced-open-file-spec.js
+++ b/spec/advanced-open-file-spec.js
@@ -592,7 +592,7 @@ describe('Functional tests', () => {
 
         it('can open files in new split panes', () => {
             atom.workspace.open(fixturePath('sample.js'));
-            expect(atom.workspace.getPanes().length).toEqual(1);
+            const initialPaneCount = atom.workspace.getPanes().length;
 
             setPath(fixturePath('prefix_match.js'));
             dispatch('pane:split-left');
@@ -603,7 +603,7 @@ describe('Functional tests', () => {
                     fixturePath('sample.js'),
                     fixturePath('prefix_match.js'),
                 ]));
-                expect(atom.workspace.getPanes().length).toEqual(2);
+                expect(atom.workspace.getPanes().length).toEqual(initialPaneCount + 1);
             });
         });
 
@@ -728,6 +728,13 @@ describe('Functional tests', () => {
             moveDown(2); // examples folder
             dispatch('application:add-project-folder');
             expect(atom.project.getPaths()).toEqual([fixturePath('examples')]);
+        });
+
+        it('will attempt to add the current path if no path if no path is selected', () => {
+            atom.project.setPaths([]);
+            setPath(fixturePath() + stdPath.sep);
+            dispatch('application:add-project-folder');
+            expect(atom.project.getPaths()).toEqual([fixturePath()]);
         });
 
         it('beeps when trying to add the parent folder as a project directory', () => {


### PR DESCRIPTION
Hi! I'm coming to atom from emacs, and advanced-open-file rocks.

I'd love to save the down keystroke when I'm adding a project folder. This patch would allow using the currentPath, if it's a folder. 