### PR TITLE
Hide files with given glob patterns

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -45,5 +45,11 @@ export let config = {
                       details.`,
         type: 'boolean',
         default: false,
+    },
+    ignoredFiles: {
+      title: "Ignore files with these extensions",
+      description: "Don't show files with the given extensions.",
+      type: 'string',
+      default: '.pyc,~',
     }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,10 +46,13 @@ export let config = {
         type: 'boolean',
         default: false,
     },
-    ignoredFiles: {
-      title: "Ignore files with these extensions",
-      description: "Don't show files with the given extensions.",
-      type: 'string',
-      default: '.pyc,~',
+    ignoredPatterns: {
+      title: 'Ignore patterns',
+      description: 'Array of glob patterns to hide matching filenames.',
+      type: 'array',
+      default: ['*.pyc', '*.pyo'],
+      items: {
+          type: 'string',
+      },
     }
 };

--- a/lib/models.js
+++ b/lib/models.js
@@ -13,6 +13,7 @@ import {
     cachedProperty,
     defineImmutable,
     getProjectPath,
+    ignoredPatterns,
     preferredSeparatorFor
 } from './utils';
 
@@ -56,16 +57,6 @@ export class Path {
 
     isFile() {
         return this.stat ? !this.stat.isDirectory() : null;
-    }
-
-    isVisible() {
-      ignoredFiles = config.get('ignoredFiles');
-      if (!ignoredFiles) return true;
-      ignoredExtensions = ignoredFiles.split(',');
-      for( i in ignoredExtensions) {
-        if(this.fragment.endsWith(ignoredExtensions[i])) return false;
-      }
-      return true;
     }
 
     isProjectDirectory() {
@@ -157,6 +148,7 @@ export class Path {
             }
         }
 
+        filenames = filenames.filter(isVisible)
         return filenames.map((fn) => new Path(this.directory + fn));
     }
 
@@ -248,4 +240,14 @@ function matchFragment(fragment, filename, caseSensitive=false) {
     }
 
     return filename.startsWith(fragment);
+}
+
+/**
+ * Return whether the filename is not hidden by the ignoredPatterns config.
+ */
+function isVisible(filename) {
+    for (const ignoredPattern of ignoredPatterns()) {
+        if (ignoredPattern.match(filename)) return false;
+    }
+    return true;
 }

--- a/lib/models.js
+++ b/lib/models.js
@@ -58,6 +58,14 @@ export class Path {
         return this.stat ? !this.stat.isDirectory() : null;
     }
 
+    isVisible() {
+      ignoredExtensions = config.get('ignoredFiles').split(',');
+      for( i in ignoredExtensions) {
+        if(this.fragment.endsWith(ignoredExtensions[i])) return false;
+      }
+      return true;
+    }
+
     isProjectDirectory() {
         return atom.project.getPaths().indexOf(this.absolute) !== -1;
     }

--- a/lib/models.js
+++ b/lib/models.js
@@ -59,7 +59,9 @@ export class Path {
     }
 
     isVisible() {
-      ignoredExtensions = config.get('ignoredFiles').split(',');
+      ignoredFiles = config.get('ignoredFiles');
+      if (!ignoredFiles) return true;
+      ignoredExtensions = ignoredFiles.split(',');
       for( i in ignoredExtensions) {
         if(this.fragment.endsWith(ignoredExtensions[i])) return false;
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,11 @@
 /** @babel */
 
+import minimatch from 'minimatch';
 import stdPath from 'path';
 
 import osenv from 'osenv';
+
+import * as config from './config';
 
 
 /**
@@ -134,4 +137,18 @@ export function closest(selector) {
     } else {
         return null;
     }
+}
+
+
+/**
+ * Returns an array of Minimatch instances to test whether a filename
+ * is ignored. Cache the Minimatch instances instead of re-compiling
+ * the regexp.
+ */
+export function ignoredPatterns() {
+    if (this.minimatches === undefined ) {
+        const ignoredGlobs = config.get('ignoredPatterns');
+        this.minimatches = ignoredGlobs.map((glob) => new minimatch.Minimatch(glob))
+    }
+    return this.minimatches;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 import minimatch from 'minimatch';
 import stdPath from 'path';
+import StringMap from 'stringmap';
 
 import osenv from 'osenv';
 
@@ -141,14 +142,26 @@ export function closest(selector) {
 
 
 /**
+ * Return value from StringMap if exists
+ * otherwise generate value with getValue, set the StringMap and return
+ */
+export function getOrUpdateStringMap(stringMap, key, getValue) {
+  if (stringMap.has(key) ) {
+    return stringMap.get(key);
+  }
+  const value = getValue(key);
+  stringMap.set(key, value);
+  return value;
+}
+
+/**
  * Returns an array of Minimatch instances to test whether a filename
  * is ignored. Cache the Minimatch instances instead of re-compiling
  * the regexp.
  */
+let _minimatchesCache = StringMap();
 export function ignoredPatterns() {
-    if (this.minimatches === undefined ) {
-        const ignoredGlobs = config.get('ignoredPatterns');
-        this.minimatches = ignoredGlobs.map((glob) => new minimatch.Minimatch(glob))
-    }
-    return this.minimatches;
+    const ignoredGlobs = config.get('ignoredPatterns')
+    return ignoredGlobs.map((glob) => getOrUpdateStringMap(_minimatchesCache, glob, (glob) =>
+       new minimatch.Minimatch(glob)))
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -235,7 +235,7 @@ export default class AdvancedOpenFileView {
                 // Split list into directories and files and sort them.
                 paths = paths.sort(Path.compare);
                 let directoryPaths = paths.filter((path) => path.isDirectory());
-                let filePaths = paths.filter((path) => path.isFile() && path.isVisible());
+                let filePaths = paths.filter((path) => path.isFile());
                 this._appendToPathList(directoryPaths);
                 this._appendToPathList(filePaths);
             } else {

--- a/lib/view.js
+++ b/lib/view.js
@@ -235,7 +235,7 @@ export default class AdvancedOpenFileView {
                 // Split list into directories and files and sort them.
                 paths = paths.sort(Path.compare);
                 let directoryPaths = paths.filter((path) => path.isDirectory());
-                let filePaths = paths.filter((path) => path.isFile());
+                let filePaths = paths.filter((path) => path.isFile() && path.isVisible());
                 this._appendToPathList(directoryPaths);
                 this._appendToPathList(filePaths);
             } else {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "mkdirp": "^0.5.1",
     "minimatch": "^3.0.4",
     "osenv": "^0.1.3",
-    "touch": "^1.0.0"
+    "touch": "^1.0.0",
+    "stringmap": "~0.2.2"
   },
   "devDependencies": {
     "babel": "^5.8.35",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "event-kit": "^1.3.0",
     "fuzzaldrin-plus": "^0.3.1",
     "mkdirp": "^0.5.1",
+    "minimatch": "^3.0.4",
     "osenv": "^0.1.3",
     "touch": "^1.0.0"
   },


### PR DESCRIPTION
This MR allows to hide certain files in the list, using their extension. Example: hides `.pyc` files.