### PR TITLE
[WIP] prompt confirmation before opening a new file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,13 @@ export let config = {
         type: 'boolean',
         default: false,
     },
+    newFileConfirmation: {
+        title: 'Prompt confirmation on new file',
+        description: `When opening files that don't exist, Prompt confirmation
+                      before opening tab.`,
+        type: 'boolean',
+        default: false,
+    },
     helmDirSwitch: {
         title: 'Shortcuts for fast directory switching',
         description: 'See README for details.',

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -122,6 +122,32 @@ export class AdvancedOpenFileController {
         this.openPath(path);
     }
 
+    openNewFile(path) {
+        if (config.get('newFileConfirmation')) {
+            if (this.newFileWaitingForConfirmation != path) {
+                atom.beep();
+                this.newFileWaitingForConfirmation = path;
+                return;
+            }
+        }
+        try {
+            path.createDirectories();
+            if (config.get('createFileInstantly')) {
+                path.createFile();
+                emitter.emit('did-create-path', path.absolute);
+            }
+            atom.workspace.open(path.absolute);
+            emitter.emit('did-open-path', path.absolute);
+        } catch (err) {
+            atom.notifications.addError('Could not open file', {
+                detail: err,
+                icon: 'alert',
+            });
+        } finally {
+            this.detach();
+        }
+    }
+
     openPath(path) {
         if (path.exists()) {
             if (path.isFile()) {
@@ -132,22 +158,7 @@ export class AdvancedOpenFileController {
                 atom.beep();
             }
         } else if (path.fragment) {
-            try {
-                path.createDirectories();
-                if (config.get('createFileInstantly')) {
-                    path.createFile();
-                    emitter.emit('did-create-path', path.absolute);
-                }
-                atom.workspace.open(path.absolute);
-                emitter.emit('did-open-path', path.absolute);
-            } catch (err) {
-                atom.notifications.addError('Could not open file', {
-                    detail: err,
-                    icon: 'alert',
-                });
-            } finally {
-                this.detach();
-            }
+            this.openNewFile(path)
         } else if (config.get('createDirectories')) {
             try {
                 path.createDirectories();

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -26,6 +26,7 @@ export class AdvancedOpenFileController {
         this.currentPath = null;
         this.pathHistory = [];
         this.disposables = new CompositeDisposable();
+        this.isWaitingForNewFileConfirmation = false;
 
         this.disposables.add(atom.commands.add('atom-workspace', {
             'advanced-open-file:toggle': ::this.toggle
@@ -63,7 +64,8 @@ export class AdvancedOpenFileController {
         this.selectPath(new Path(fileName));
     }
 
-    pathChange(newPath)  {
+    pathChange(newPath) {
+        this.stopWaitingNewFileConfirmation()
         this.currentPath = newPath;
 
         let replace = false;
@@ -124,10 +126,13 @@ export class AdvancedOpenFileController {
 
     openNewFile(path) {
         if (config.get('newFileConfirmation')) {
-            if (this.newFileWaitingForConfirmation != path) {
+            if (!this.isWaitingForNewFileConfirmation) {
+                this.isWaitingForNewFileConfirmation = true;
+                this.view.showNewFileConfirmation();
                 atom.beep();
-                this.newFileWaitingForConfirmation = path;
                 return;
+            } else {
+              this.stopWaitingNewFileConfirmation();
             }
         }
         try {
@@ -300,6 +305,7 @@ export class AdvancedOpenFileController {
         }
 
         this.view.setCursorIndex(index);
+        this.stopWaitingNewFileConfirmation();
     }
 
     moveCursorUp() {
@@ -311,21 +317,24 @@ export class AdvancedOpenFileController {
         }
 
         this.view.setCursorIndex(index);
+        this.stopWaitingNewFileConfirmation();
     }
 
     moveCursorTop() {
         this.view.setCursorIndex(0);
+        this.stopWaitingNewFileConfirmation();
     }
 
     moveCursorBottom() {
         this.view.setCursorIndex(this.view.pathListLength() - 1);
+        this.stopWaitingNewFileConfirmation();
     }
 
     detach() {
         if (this.panel === null) {
             return;
         }
-
+        this.stopWaitingNewFileConfirmation();
         this.panel.destroy();
         this.panel = null;
         atom.workspace.getActivePane().activate();
@@ -341,5 +350,10 @@ export class AdvancedOpenFileController {
         this.currentPath = initialPath;
         this.updatePath(Path.initial(), {saveHistory: false});
         this.panel = this.view.createModalPanel();
+    }
+
+    stopWaitingNewFileConfirmation() {
+        this.isWaitingForNewFileConfirmation = false;
+        this.view.hideNewFileConfirmation();
     }
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -73,7 +73,8 @@ export default class AdvancedOpenFileView {
         return dom(`
             <div class="advanced-open-file">
                 <p class="info-message icon icon-file-add">
-                    Enter the path for the file to open or create.
+                    <span class="default-info-message">Enter the path for the file to open or create.</span>
+                    <span class="prompt-confirmation-message">File does not exist; hit [Enter] again to create it.</span>
                 </p>
                 <div class="path-input-container">
                     <atom-text-editor class="path-input" mini></atom-text-editor>
@@ -286,5 +287,19 @@ export default class AdvancedOpenFileView {
                 }
             }
         }
+    }
+
+    showNewFileConfirmation() {
+        let defaultInfoMessage = this.content.querySelector('.default-info-message');
+        let promptMessage = this.content.querySelector('.prompt-confirmation-message');
+        defaultInfoMessage.style.display = 'none';
+        promptMessage.style.display = 'inline';
+    }
+
+    hideNewFileConfirmation() {
+        let defaultInfoMessage = this.content.querySelector('.default-info-message');
+        let promptMessage = this.content.querySelector('.prompt-confirmation-message');
+        defaultInfoMessage.style.display = 'inline';
+        promptMessage.style.display = 'none';
     }
 }

--- a/styles/advanced-open-file.less
+++ b/styles/advanced-open-file.less
@@ -16,6 +16,11 @@
     .info-message {
         flex: 0 0 1.5em;
         margin-bottom: 0.75em;
+
+        .prompt-confirmation-message {
+            display: none;
+            color: @text-color-success;
+        }
     }
 
     .path-input-container {


### PR DESCRIPTION
## Current issue

It's pretty common to unintentionally open a new file instead of an existing one. A typical use case is when typing [tab] then immediately [enter] without checking that [tab] didn't auto-completed the entire filename. Closing the opened new file is then "slow" because it prompt a native "confirmation" splash screen ("don't save", "cancel", "[save]").


## Proposal

Require a quick confirmation before opening a new file. The current proposal is to type [enter] twice. The first [enter] beeps.
I'm using the WIP implementation from this PR for months, and I'm confident it's satisfying from a user point of view:)


## UI Discussion: prompt message

I haven't implemented any message to the user asking for confirmation. I would like to open a discussion on where would be the best place for this message:
* Option A: replace the text in `info-message`
* Option B: inside the `path-input` to the right of the cursor
* other idea?

## TODO
* [x] ui message
* [ ] tests
